### PR TITLE
nerve service should force upstart provider

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -19,6 +19,7 @@ class nerve::service {
     enable     => $nerve::service_enable,
     hasstatus  => true,
     hasrestart => true,
+    provider   => upstart,
   }
 
 }


### PR DESCRIPTION
This fixes this module on CentOS, where upstart isn't the default service provider.
