### PR TITLE
use initctl to control service on redhat 6

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,6 +16,7 @@ class nerve (
   $config_file      = $nerve::params::config_file,
   $config_dir       = $nerve::params::config_dir,
   $purge_config     = $nerve::params::purge_config,
+  $log_file         = $nerve::params::log_file,
   $instance_id      = $nerve::params::instance_id
 ) inherits nerve::params {
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,6 +16,7 @@ class nerve::params {
       $config_file      = '/etc/nerve/nerve.conf.json'
       $config_dir       = '/etc/nerve/conf.d/'
       $purge_config     = true
+      $log_file         = '/var/log/nerve.log'
       $instance_id      = $::fqdn
     }
     default: {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -13,12 +13,26 @@ class nerve::service {
     group   => 'root',
     mode    => 0444,
     content => template('nerve/nerve.conf.upstart.erb'),
-  } ~>
-  service { 'nerve':
-    ensure     => $nerve::service_ensure,
-    enable     => $nerve::service_enable,
-    hasstatus  => true,
-    hasrestart => true,
+  }
+
+  if $osfamily == 'RedHat' and $operatingsystemmajrelease == 6 {
+    service { 'nerve':
+      ensure     => $nerve::service_ensure,
+      enable     => false,
+      hasstatus  => true,
+      start      => '/sbin/initctl start nerve',
+      stop       => '/sbin/initctl stop nerve',
+      status     => '/sbin/initctl status nerve | grep "/running" 1>/dev/null 2>&1',
+      subscribe  => File['/etc/init/nerve.conf'],
+    }
+  } else {
+    service { 'nerve':
+      ensure     => $nerve::service_ensure,
+      enable     => $nerve::service_enable,
+      hasstatus  => true,
+      hasrestart => true,
+      subscribe  => File['/etc/init/nerve.conf'],
+    }
   }
 
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -35,4 +35,17 @@ class nerve::service {
     }
   }
 
+  $log_file = $nerve::log_file
+  $nobody_group = $osfamily ? {
+    'RedHat' => 'nobody',
+    default  => 'nogroup',
+  }
+
+  file { $log_file:
+    ensure => file,
+    owner  => nobody,
+    group  => $nobody_group,
+    mode   => 660,
+  }
+
 }

--- a/templates/nerve.conf.upstart.erb
+++ b/templates/nerve.conf.upstart.erb
@@ -7,4 +7,4 @@ respawn
 respawn limit 10 5
 
 # Backwards compatibility to run as nobody
-exec su -s /bin/sh -c 'exec "$0" "$@"' nobody -- nerve --config <%= @config_file %>
+exec sudo -u nobody -- nerve --config <%= @config_file %> >> <%= @log_file %> 2>&1


### PR DESCRIPTION
This works around puppet trying to use `service` to control an upstart job on CentOS 6.
